### PR TITLE
Add support for inner-background-color and inner-border-radius

### DIFF
--- a/src/components/Column.ts
+++ b/src/components/Column.ts
@@ -19,6 +19,8 @@ export default (editor: grapesjs.Editor, { opt, coreMjmlModel, coreMjmlView, san
           'background-color', 'vertical-align', 'width',
           'border-radius', 'border-top-left-radius', 'border-top-right-radius', 'border-bottom-left-radius', 'border-bottom-right-radius',
           'border', 'border-width', 'border-style', 'border-color',
+          'inner-background-color',
+          'inner-border-radius',
         ],
         'style-default': {
           'vertical-align': 'top'
@@ -111,7 +113,7 @@ export default (editor: grapesjs.Editor, { opt, coreMjmlModel, coreMjmlView, san
       },
 
       getChildrenSelector() {
-        return 'table';
+        return 'table > tbody > tr > td > table';
       },
     },
   });

--- a/src/style.ts
+++ b/src/style.ts
@@ -98,7 +98,19 @@ export default (editor: grapesjs.Editor, opt: RequiredPluginOptions) => {
           name: 'Background color',
           property: 'container-background-color',
           type: 'color',
+        },
+        {
+          name: 'Background color',
+          property: 'inner-background-color',
+          type: 'color',
         }, {
+          name: 'Border radius',
+          property: 'inner-border-radius',
+          type: 'integer',
+          defaults: '0px',
+          units: ['px', '%']
+        },
+         {
           property: 'background-url',
           type: 'file',
         }, {


### PR DESCRIPTION
Hi i want to add support for the attribute inner-background-color and inner-border-radius for mj-column component

Now editor able to create this

![image](https://user-images.githubusercontent.com/59781669/219266340-308fd737-69ab-4df4-93c4-72f5db6ff623.png)

@artf or @DRoet can check it?