### PR TITLE
Added colorScheme option and customClasses options for blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>GrapesJS Plugin</title>
   <link href="https://unpkg.com/grapesjs/dist/css/grapes.min.css" rel="stylesheet">
   <script src="https://unpkg.com/grapesjs"></script>
+  <script src="./dist/index.js"></script>
   <style>
     body,
     html {
@@ -25,6 +26,20 @@
       border: none !important;
       background: transparent !important;
       box-shadow: none !important;
+    }
+
+    .lbl-custom-label{
+      text-transform: uppercase;
+    }
+
+    .custom-block-cls{
+      transition: all 300ms ease-out;
+    }
+
+    .custom-block-cls:hover{
+      cursor: pointer;
+      border: 1px solid rgb(0,0,4);
+      box-shadow: 0px 0px 16px 16px rgba(0,0,4,0.4);
     }
   </style>
 </head>
@@ -149,6 +164,22 @@
   <script type="text/javascript">
     // Wait for the plugin to be injected by the dev server
     setTimeout(() => {
+
+      const myRawId = "mj-raw-custom";
+      const myRawComponent = {
+      label: 'Images3',
+      media: `<svg viewBox="0 0 24 24">
+          <path fill="currentColor" d="M12,17.56L16.07,16.43L16.62,10.33H9.38L9.2,8.3H16.8L17,6.31H7L7.56,12.32H14.45L14.22,14.9L12,15.5L9.78,14.9L9.64,13.24H7.64L7.93,16.43L12,17.56M4.07,3H19.93L18.5,19.2L12,21L5.5,19.2L4.07,3Z" />
+      </svg>`,
+      content: `<mj-raw>
+        <div class="container">
+          <img class="item" src="https://source.unsplash.com/random/200x141" alt="Example image">
+          <img class="item" src="https://source.unsplash.com/random/200x142" alt="Example image">
+          <img class="item" src="https://source.unsplash.com/random/200x143" alt="Example image">
+        </div>
+      </mj-raw>`,
+  }
+
       window.editor = grapesjs.init({
         height: '100%',
         noticeOnUnload: 0,
@@ -158,9 +189,24 @@
 
         plugins: ['grapesjs-mjml'],
         pluginsOpts: {
-          'grapesjs-mjml': {}
+          'grapesjs-mjml': {
+            colorScheme: {
+              primaryColor: '#FFF',
+              secondaryColor: '#3D3D3D',
+              quaternaryColor: '#0074D9'
+            },
+            customClasses: {
+              blocks: {
+                class: 'custom-block-cls',
+                label: 'lbl-custom-label',
+                vector: 'custom-vec-cls'
+              }
+            }
+          }
         }
       });
+
+      window.editor.Blocks.add(myRawId, myRawComponent);
     }, 100);
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -186,7 +186,12 @@
         storageManager: {autoload: 0},
         container: '#gjs',
         fromElement: true,
-
+        assetManager: {
+          custom: true,
+          assets: [
+            'https://img.freepik.com/free-vector/giant-check-list_23-2148087771.jpg'
+          ]
+        },
         plugins: ['grapesjs-mjml'],
         pluginsOpts: {
           'grapesjs-mjml': {
@@ -207,6 +212,28 @@
       });
 
       window.editor.Blocks.add(myRawId, myRawComponent);
+
+      function handleAssetsUI(e){
+        if(!e.open) return;
+        
+        const uiElement = document.createElement('div');
+        uiElement.classList.add("custom-assets-ui");
+
+        e.assets.forEach(a => {
+          let imgElem = document.createElement('img');
+          imgElem.src = a.attributes.src
+          imgElem.style.width = '240px'
+          imgElem.style.height = '240px'
+          uiElement.appendChild(imgElem); 
+        })
+        e.container.appendChild(uiElement);
+      }
+
+      window.editor.on('asset:custom', handleAssetsUI);
+
+      window.editor.on("asset:close", () => 
+        window.editor.off('asset:custom', handleAssetsUI)
+      );
     }, 100);
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
   <title>GrapesJS Plugin</title>
   <link href="https://unpkg.com/grapesjs/dist/css/grapes.min.css" rel="stylesheet">
   <script src="https://unpkg.com/grapesjs"></script>
-  <script src="./dist/index.js"></script>
   <style>
     body,
     html {
@@ -186,12 +185,6 @@
         storageManager: {autoload: 0},
         container: '#gjs',
         fromElement: true,
-        assetManager: {
-          custom: true,
-          assets: [
-            'https://img.freepik.com/free-vector/giant-check-list_23-2148087771.jpg'
-          ]
-        },
         plugins: ['grapesjs-mjml'],
         pluginsOpts: {
           'grapesjs-mjml': {
@@ -212,28 +205,6 @@
       });
 
       window.editor.Blocks.add(myRawId, myRawComponent);
-
-      function handleAssetsUI(e){
-        if(!e.open) return;
-        
-        const uiElement = document.createElement('div');
-        uiElement.classList.add("custom-assets-ui");
-
-        e.assets.forEach(a => {
-          let imgElem = document.createElement('img');
-          imgElem.src = a.attributes.src
-          imgElem.style.width = '240px'
-          imgElem.style.height = '240px'
-          uiElement.appendChild(imgElem); 
-        })
-        e.container.appendChild(uiElement);
-      }
-
-      window.editor.on('asset:custom', handleAssetsUI);
-
-      window.editor.on("asset:close", () => 
-        window.editor.off('asset:custom', handleAssetsUI)
-      );
     }, 100);
   </script>
 </body>

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -15,7 +15,22 @@ export default (editor: grapesjs.Editor, opts: RequiredPluginOptions) => {
       select: true,
       // @ts-ignore
       category: editor.I18n.t('grapesjs-mjml.category'),
-      ...def,
+      label: opts?.customClasses?.blocks?.label 
+              ? `
+              <div class="${opts?.customClasses?.blocks?.label}">
+                ${def.label}
+              </div>` 
+             : def.label,
+      media: opts?.customClasses?.blocks?.vector ?
+              `<div class="${opts?.customClasses?.blocks?.vector}">
+                ${def.media}
+                </div>
+              ` :
+              def.media,
+      content: def.content,
+      attributes: {
+        class: opts?.customClasses?.blocks?.class
+      },
       ...opts.block(id),
     });
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,11 +111,33 @@ export type PluginOptions = {
    */
   fonts?: Record<string, any>;
 
+  // /**
+  //  * Load custom preset theme.
+  //  * @default true
+  //  */
+  // useCustomTheme?: boolean;
+
   /**
-   * Load custom preset theme.
-   * @default true
+   * Custom Color Palette
+   * @default {}
    */
-  useCustomTheme?: boolean;
+  colorScheme?: {
+    primaryColor?: string,
+    secondaryColor?: string,
+    quaternaryColor?: string
+  },
+
+  /**
+   * Custom Class Names
+   * @default {}
+   */
+  customClasses?: {
+    blocks?: {
+      class?: string,
+      vector?: string,
+      label?: string
+    }
+  }
 };
 
 export type RequiredPluginOptions = Required<PluginOptions>;
@@ -138,12 +160,14 @@ const plugin: grapesjs.Plugin<PluginOptions> = (editor, opt = {}) => {
     resetDevices: true,
     hideSelector: true,
     useXmlParser: false,
-    useCustomTheme: true,
+    // useCustomTheme: true,
     columnsPadding: '10px 0',
     i18n: {},
     fonts: {},
     // Export 'mjml', 'html' or both (leave empty) TODO
     // exportOnly: '',
+    colorScheme: {},
+    customClasses: {},
     ...opt,
   };
 
@@ -174,10 +198,10 @@ const plugin: grapesjs.Plugin<PluginOptions> = (editor, opt = {}) => {
     editor.Parser.getConfig().optionsHtml.htmlType = 'text/xml';
   }
 
-  if (opts.useCustomTheme && typeof window !== 'undefined') {
-    const primaryColor = '#2c2e35';
-    const secondaryColor = '#888686';
-    const quaternaryColor = '#f45e43';
+  // if (opts.useCustomTheme && typeof window !== 'undefined') {
+    const primaryColor = opts.colorScheme?.primaryColor || '#2c2e35';
+    const secondaryColor = opts.colorScheme?.secondaryColor || '#888686';
+    const quaternaryColor = opts.colorScheme?.quaternaryColor || '#f45e43';
     const prefix = 'gjs-';
     let cssString = '';
 
@@ -202,7 +226,7 @@ const plugin: grapesjs.Plugin<PluginOptions> = (editor, opt = {}) => {
     const style = document.createElement('style');
     style.innerText = cssString;
     document.head.appendChild(style);
-  }
+  // }
 
   // @ts-ignore Load i18n files
   editor.I18n.addMessages({


### PR DESCRIPTION
+ Added support for easy theming. `colorScheme` option is available in `PluginOptions` with `primaryColor`, `secondaryColor` and `quaternaryColor` as string props to add hex color codes to override the default color scheme.
+ Added support for easy customization of blocks. `customClasses` option available in `PluginOptions` with `blocks` prop which handles the customClasses for blocks. This prop contains `vector` prop to wrap the svg element with a `div` element with the class provided as the string value. `text` prop handles custom class for the label `div` wrapper. `class` prop can be used to apply custom class on the parent `div` wrapper for the block. The classes of `block` prop are applied on all the blocks to make all blocks share the same class which can be used to easily customize their look and feel.
+ `index.html` demonstrates how to use the new plugin options 