### PR TITLE
fix: Make headless mode work without jsdom #392

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -40,7 +40,7 @@ export default (editor: Editor, opt: RequiredPluginOptions) => {
   const { Components } = editor;
   // @ts-ignore
   const ComponentsView = Components.ComponentsView;
-  const sandboxEl = document.createElement('div');
+  const sandboxEl = editor.getConfig().headless ? undefined as unknown as HTMLDivElement : document.createElement('div');
 
   // MJML Core model
   let coreMjmlModel = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import type { Plugin } from 'grapesjs';
 import loadBlocks from './blocks';
 import loadCommands from './commands';
 import loadComponents from './components';
-import mjml2html from './components/parser';
 import en from './locale/en';
 import loadPanels from './panels';
 import loadStyle from './style';
@@ -36,7 +35,7 @@ const plugin: Plugin<PluginOptions> = (editor, opt = {}) => {
     customComponents: [],
     importPlaceholder: '',
     imagePlaceholderSrc: '',
-    mjmlParser: mjml2html,
+    mjmlParser: opt.mjmlParser ? opt.mjmlParser : require("./components/parser"),
     overwriteExport: true,
     preMjml: '',
     postMjml: '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const plugin: Plugin<PluginOptions> = (editor, opt = {}) => {
     customComponents: [],
     importPlaceholder: '',
     imagePlaceholderSrc: '',
-    mjmlParser: opt.mjmlParser ? opt.mjmlParser : require("./components/parser"),
+    mjmlParser: mjml2html,
     overwriteExport: true,
     preMjml: '',
     postMjml: '',


### PR DESCRIPTION
Remove the use of document element when in headless mode.
Import mjml browser only if another parser wasn't provided.